### PR TITLE
Fix corrupt screen on some apps, and minimal support for V-TEXT

### DIFF
--- a/ctmouse.asm
+++ b/ctmouse.asm
@@ -434,7 +434,7 @@ endif						; -X- USERIL
 ;----- for DOS/V support -----
 if DBCSDOSV
 	dbcsstrbuf	db	4*81 dup (?)	;max 80 chr in line
-	dbcsint10calling	db	0
+	oldint10calling	db	0
 ifdef DBCSDOSVDEBUG
 	dbcsdebugtext	db	2*80 dup (?)
 DEBUGOUT	macro	val	;logging to 86Box POST card
@@ -1322,7 +1322,16 @@ if USERIL					; -X-
 		cmp	ah,0FAh
 		je	@@RIL_FA
 endif						; -X- USERIL
+if DBCSDOSV
+@@jmpold10:
+		inc	cs: [oldint10calling]
+		pushf
+		call_far oldint10
+		dec	cs: [oldint10calling]
+		iret
+else
 @@jmpold10:	jmp_far	oldint10
+endif
 
 @@setnewfont:	cmp	al,10h
 		jb	@@jmpold10
@@ -1338,8 +1347,15 @@ endif						; -X- USERIL
 		push	cs			;  Windows driver workaround
 		call	handler33		; hide mouse cursor
 		pop	ax
+if DBCSDOSV
+		inc	cs: [oldint10calling]
 		pushf
-		call	[oldint10]
+		call	cs: [oldint10]
+		dec	cs: [oldint10calling]
+else
+		pushf
+		call	cs: [oldint10]
+endif
 		push	ds
 		push	es
 		PUSHALL
@@ -2371,11 +2387,11 @@ checkifseen	endp
 if DBCSDOSV
 
 INT10RWCHARDOSV		macro
-	mov	[dbcsint10calling],1
+;	mov	[dbcsint10calling],1
 ;	pushf
 ;	call	[oldint10]
 	int	10h
-	mov	[dbcsint10calling],0
+;	mov	[dbcsint10calling],0
 endm
 
 ;========================================================================
@@ -2383,14 +2399,14 @@ endm
 ;========================================================================
 ; In:   ES:BP (char buffer), DS:SI
 ; Out:	
-; Use:	dbcsint10calling, granpos.x, cursorwidth, startscan, endscan
+; Use:	oldint10calling, granpos.x, cursorwidth, startscan, endscan
 ; Modf:	AX, BX, CX, DX, ES, BP, dbcscursorposh, dbcscursorposw, 
 ;		dbcsbufsize, dbcsbuf1, dbcsbuf2, textbuf
 ; Call:	getattrdbcs, INT10RWCHARDOSV
 storedbcsattr	proc
 	;convert vscreen x-y to box x-y
-	cmp [dbcsint10calling], 1
-	je	@@skipall
+	cmp [oldint10calling], 0
+	jne	@@skipall
 	mov	ax,[granpos.Y]	;current cursor y position (px)
 	;mov bx,8			;height of character (px)
 	;div	bx
@@ -2444,13 +2460,13 @@ storedbcsattr endp
 ;========================================================================
 ; In:   none
 ; Out:	none
-; Use:	dbcsint10calling, granpos.x, cursorwidth, startscan, endscan
+; Use:	oldint10calling, granpos.x, cursorwidth, startscan, endscan
 ; Modf:	AX, BX, CX, DX, ES, BP, 
 ;		dbcsbufsize, dbcsbuf1, dbcsbuf2, textbuf
 ; Call:	getattrdbcs, INT10RWCHARDOSV
 restoredbcsattr	proc
-	cmp [dbcsint10calling],1
-	je	@@skipall
+	cmp [oldint10calling], 0
+	jne	@@skipall
 	mov	dx,word ptr [dbcscursorposw]
 	call	getattrdbcs
 	;cl = (1: SBCS, 2: DBCS 1st/2nd)

--- a/ctmouse.asm
+++ b/ctmouse.asm
@@ -46,6 +46,7 @@ USE28		 = 0		; include code for INT 33/0028 function
 USERIL           = 0		; include code for INT 10/Fn EGA functions
 DBCSDOSV	 = 1        ; include code for DOS/V
 DBCSMSG	     = 1        ; enable bilingual message for DOS/V
+VTEXT		 = (1 AND DBCSDOSV)	; support over 80x25 text mode for DOS/V
 
 ; %define PS2DEBUG 1		; print debug messages for PS2serv calls
 ; DBCSDOSVDEBUG	 = 1        ; debug code for DOS/V
@@ -433,7 +434,11 @@ endif						; -X- USERIL
 
 ;----- for DOS/V support -----
 if DBCSDOSV
+if VTEXT
+	dbcsstrbuf	db	4*256 dup (?)	;max 255 chr in line
+else
 	dbcsstrbuf	db	4*81 dup (?)	;max 80 chr in line
+endif
 	oldint10calling	db	0
 ifdef DBCSDOSVDEBUG
 	dbcsdebugtext	db	2*80 dup (?)
@@ -2510,7 +2515,7 @@ getattrdbcs	proc
 ;	jae		@@midtext	; char pos x >=2
 ;	add		cl,2		; to determine if the char is DBCS
 	mov		dl,0		; read characters from the head of the line
-	inc		cl
+	inc		cx
 ;	jmp		@@readchr
 ;@@midtext: this doesn't recognize a DBCS sequence include lead-byte range only.
 ;           so we need seek the entire bytes in the line


### PR DESCRIPTION
一部ソフト上での表示不具合の修正と、最小限のV-Text対応を行ったものとなります。

表示不具合修正：  
DOS/Vテキストモードでマウスを使用する一部のソフトで、画面表示更新中にマウスを激しく動かすと画面の表示が乱れたりフリーズすることがある。
MS-DOS 6.2/V付属のHELPとEDIT（実際の動作バイナリは同じ）、DOS/V版Windows 3.1J付属のMSDで確認。
int 10hの再入チェックをやや強めにすることでひとまず対応してみました。

V-Text対応：  
行バッファを80→255文字相当に。常駐サイズも増加。