### PR TITLE
Added support for V-Text (video mode 70h and 71h)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,15 @@
 # CTMOUSEV (CuteMouse with DOS/V support)
+
 CTMOUSEV is a compact mouse driver for DOS/V, based on the CuteMouse driver from the FreeDOS project.
 
 The mouse support depends on your motherboard. When you use this driver with a PS/2 or USB mouse, the driver doesn't communicate with a mouse directly. Basically, it uses INT 15h mouse functions in the BIOS.
 
 Bret Johnson's DOS USB Drivers provides INT 15h mouse fuctions for USB mice. Using both drivers allows you to use a USB mouse without the BIOS support.
+
+The public archive (r2) includes following builds:
+
+* CTMOUSE.EXE - Mouse driver with DOS/V and V-Text (video mode 70h, 71h) support with English / Japanese localized messages.
+* CTMOUSEM.EXE - Mouse driver with DOS/V support.
 
 # CuteMouse from github.com/davidebreso/ctmouse
 
@@ -14,5 +20,5 @@ This repository hosts a version of CuteMouse v2.1b4 converted to compile with Jw
 ## License
 
 * CuteMouse ant this repository as a whole are distributed under the terms of the GPL version 2. See the `copying` file for more details. 
-* `bin2exe.c` is a modified version of the `bin2exe` utility included in [booterify](https://github.com/raphnet/booterify), developed by Raphaël Assenat and distributed under the MIT License.
+* `bin2exe.c` is a modified version of the `bin2exe` utility included in [booterify](https://github.com/raphnet/booterify), developed by Rapha谷l Assenat and distributed under the MIT License.
 

--- a/ctm-en.msg
+++ b/ctm-en.msg
@@ -29,7 +29,7 @@ S_inLT		db 'Logitech mode',eos
 S_wheel		db ' (wheel present)'
 S_CRLF		db nl,eos
 
-Copyright	db nl,'CuteMouse v',CTMRELEASE,' with DOS/V support',nl,eos
+Copyright	db nl,'CuteMouse v',CTMRELEASE,CTMBUILD,nl,eos
 Syntax		label byte
     db 0,nl,'Options:',nl
     db '  /V	   - reverse search: find PS/2 after serial mouse',nl

--- a/ctm-ja.msg
+++ b/ctm-ja.msg
@@ -28,25 +28,25 @@ DS_inLT		db 'Logitech mode',eos
 DS_wheel		db ' (wheel present)'
 DS_CRLF		db nl,eos
 
-DCopyright	db nl,'CuteMouse v',CTMRELEASE,' with DOS/V support',nl,eos
+DCopyright	db nl,'CuteMouse v',CTMRELEASE,CTMBUILD,nl,eos
 DSyntax		label byte
     db 0,nl,'オプション：',nl
     db '  /V	   - 逆探索：シリアルマウスの後にPS/2マウスを探す',nl
-    db '  /P	   - シリアルポートを探さず、PS/2マウスモードを強制する',nl
-    db '  /S[c[i]] - COMポート c (1-4)、IRQ i (1-7) でシリアルマウスモードを強制する',nl
-    db '  /3	   - マイクロソフトまたはPS/2マウスで3ボタンモードを強制する',nl
+    db '  /P	   - シリアルポートを探さず、PS/2マウスを強制',nl
+    db '  /S[c[i]] - COMポート c (1-4)、IRQ i (1-7) でシリアルマウスを強制',nl
+    db '  /3	   - マイクロソフトまたはPS/2マウスで3ボタンモードを強制',nl
 ; Note: /O now acts inverse compared to 2.1 beta 3
-    db '  /O       - PS/2やBIOS USBホイール検出を有効にする (フリーズする可能性あり)',nl
+    db '  /O       - PS/2やBIOS USBホイール検出を有効にする (動作不安定)',nl
 ; 2008: made /Y (ignore MSys) the default and introduced /M (enable MSys)
 ;   db '  /Y	   - 非 PNPデバイスへの Mouse Systems モードを試さない',nl,nl
     db '  /M       - Mouse Systems / Genius 製の非PNPマウスを試す',nl,nl
     db '  /R[h[v]] - 水平/垂直分解能: h,v = 1-9 または 0 (自動)',nl
-    db '	     (指定無し = 既定：hを自動、vをhと同じ指定とする)',nl
-    db '  /L	   - 左右のボタンを入れ替える',nl,nl
+    db '	     (既定：hを自動、vをhと同じに指定)',nl
+    db '  /L	   - ボタンを左右入れ替える',nl,nl
 ;
-    db '  /B	   - 既に CuteMouse が常駐している場合は実行を中止する',nl
-    db '  /N	   - 既に CuteMouse が常駐していても新しく常駐する',nl
+    db '  /B	   - 既に CuteMouse が常駐している場合は実行を中止',nl
+    db '  /N	   - 既に CuteMouse が常駐していても新しく常駐',nl
     db '	     (バッチファイルの最後に解放する場合などに使用)',nl
     db '  /W	   - CuteMouse を UMB メモリーにロードしない',nl
-    db '  /U	   - CuteMouse をアンインストール、メモリーへの常駐を解放する',nl
-    db '  /?	   - このヘルプを表示する',eos
+    db '  /U	   - CuteMouse をアンインストール、メモリーへの常駐を解放',nl
+    db '  /?	   - このヘルプを表示',eos

--- a/ctmouse.asm
+++ b/ctmouse.asm
@@ -1,7 +1,7 @@
 ; CTMOUSEV - a tiny mouse driver with DOS/V support
 ;
 ; Copyright (c) 1997-2002 Nagy Daniel <nagyd@users.sourceforge.net>
-;                    2025 Akamaki <https://github.com/akmed772>
+;               2025-2026 Akamaki <https://github.com/akmed772>
 ;
 ; BIOS wheel mouse support: Ported from Konstantin Koll's public
 ; domain code into Cute Mouse by Eric Auer 2007 (places marked -X-)
@@ -34,11 +34,6 @@
 ; warn
 ; locals
 
-CTMVER		equ <"2.1">		; major driver version
-CTMRELEASE	equ <"2.1 b4V01">	; full driver version with suffixes
-driverversion	equ 705h		; imitated Microsoft driver version
-; at least 705h because our int 33 function _26 operates in 7.05+ style
-
 FASTER_CODE	 = 0		; optimize by speed instead size
 OVERFLOW_PROTECT = 0		; prevent variables overflow
 FOOLPROOF	 = 1		; check driver arguments validness
@@ -50,6 +45,18 @@ VTEXT		 = (1 AND DBCSDOSV)	; support over 80x25 text mode for DOS/V
 
 ; %define PS2DEBUG 1		; print debug messages for PS2serv calls
 ; DBCSDOSVDEBUG	 = 1        ; debug code for DOS/V
+
+CTMVER		equ <"2.1">		; major driver version
+CTMRELEASE	equ <"2.1 b4V02">	; full driver version with suffixes
+if VTEXT
+CTMBUILD	equ <" with V-Text support">	; build info
+elseif DBCSDOSV
+CTMBUILD	equ <" with DOS/V support">	; build info
+else
+CTMBUILD	equ <"">	; build info
+endif
+driverversion	equ 705h		; imitated Microsoft driver version
+; at least 705h because our int 33 function _26 operates in 7.05+ style
 
 ;------------------------------------------------------------------------
 
@@ -434,12 +441,15 @@ endif						; -X- USERIL
 
 ;----- for DOS/V support -----
 if DBCSDOSV
+	oldint10calling	db	0
+
+	db 'DBCSBuf_Begin->'
 if VTEXT
 	dbcsstrbuf	db	4*256 dup (?)	;max 255 chr in line
 else
 	dbcsstrbuf	db	4*81 dup (?)	;max 80 chr in line
 endif
-	oldint10calling	db	0
+	db '<-End_DBCSBuf'
 ifdef DBCSDOSVDEBUG
 	dbcsdebugtext	db	2*80 dup (?)
 DEBUGOUT	macro	val	;logging to 86Box POST card
@@ -2645,7 +2655,7 @@ ischardbcs endp
 ; Use:	dbcsisdosv, dbcstblptr
 ; Modf:	none
 ; Call: none
-detisdosdbcs	proc
+isdosdbcs	proc
 	push	si
 	push	ax
 	push	ds
@@ -2660,8 +2670,52 @@ detisdosdbcs	proc
 	pop	ax
 	pop	si
 	ret
-detisdosdbcs	endp
+isdosdbcs	endp
 
+;========================================================================
+;    Search a V-Text driver and get the vector address for mouse funcs
+;========================================================================
+; In:   none
+; Out:	CF (0=installed, 1=not installed or error)
+; Use:	
+; Modf:	none
+; Call: none
+;if VTEXT
+;getvtext	proc
+;	push	es
+;	push	ax
+;	push	bx
+;	push	cx
+;	mov	ax,01131h
+;	xor	cx,cx
+;	int	10h
+;	or	cx,cx
+;	jz	@@novtext	;CX=0 if the v-text driver is not installed
+;	mov	ax,05010h
+;	int	15h
+;	jc	@@novtext
+;	mov	bx,[bx+0Ah]	;get FAR pointer for the function parameter table of V-text driver
+;	mov	es,[bx+08h]
+;	SAVEFAR	[cs:vt_ptrFuncTable],es,bx
+;	mov	ax,es:[bx+0EH]	;get NEAR pointer for cursor functions
+;	mov	[cs:vt_ptrSetCursorShape],ax
+;	mov	ax,es:[bx+10H]
+;	mov	[cs:vt_ptrPutCursor],ax
+;	mov	ax,es:[bx+12H]
+;	mov	[cs:vt_ptrEraseCursor],ax
+;	clc
+;	jmp	@@endvtext
+;@@novtext:
+;	mov	word ptr [cs:vt_ptrFuncTable],0;reset pointer
+;	stc
+;@@endvtext:
+;	pop	cx
+;	pop	bx
+;	pop	ax
+;	pop	es
+;	ret
+;getvtext	endp
+;endif
 ;========================================================================
 ;    Determine the video memory is simulated
 ;========================================================================
@@ -2859,22 +2913,29 @@ endif						; -X- USERIL
 
 if DBCSDOSV
 		mov	[cs:dbcsbytesperchar],0	;reset value
-		call	detisdosdbcs
+		call	isdosdbcs
 	jz	@@notdosv
 		cmp al,3
 	je	@@vm3
 		cmp	al,073h
-	je	@@vm73
+	je	@@vm71or73
+  if VTEXT
+		cmp	al,070h
+	je	@@vm3sor70
+		cmp	al,071h
+	je	@@vm71or73
+  endif
 	jne	@@notdosv
 @@vm3:
 ; if $disp.sys is active, the actual video memory is located at A0000-AFFFFh
 		call	testb800
 	jnc	@@notdosv
-		mov	[cs:dbcsbytesperchar], 2
-	jmp	@@vm3or73end
-@@vm73:
-		mov	[cs:dbcsbytesperchar], 4
-@@vm3or73end:
+@@vm3sor70:
+		mov	[cs:dbcsbytesperchar], 2	; simulated vm3
+	jmp	@@vm3send
+@@vm71or73:
+		mov	[cs:dbcsbytesperchar], 4	; vm73
+@@vm3send:
 @@notdosv:
 endif
 
@@ -2893,6 +2954,12 @@ endif
 if DBCSDOSV
 		cmp	al,073h
 		je	@@stb
+  if VTEXT
+		cmp	al,070h
+		je	@@stb
+		cmp	al,071h
+		je	@@stb
+  endif
 endif
 ; mode 7
 		cmp	al,7
@@ -2995,7 +3062,7 @@ endif
 if DBCSDOSV
 		cmp	[dbcsbytesperchar],0
 		je	@@notdbcsvm03
-		mov	di,200
+;		mov	di,200
 @@notdbcsvm03:
 endif
 		mov	[screenheight],di
@@ -5396,7 +5463,7 @@ sayASCIIZ::
 if DBCSDOSV AND DBCSMSG
 		xchg	si,di
 		push	ax
-		call	detisdosdbcs
+		call	isdosdbcs
 		jnz		@@isdbcs
 		mov		di,[si]		;select pointer from language table
 		jmp		@@enddbcs

--- a/ctmouse.asm
+++ b/ctmouse.asm
@@ -2922,7 +2922,7 @@ endif						; -X- USERIL
 		pop	ax			; current video mode
 
 if DBCSDOSV
-		mov	[cs:dbcsbytesperchar],0	;reset value
+		mov	[dbcsbytesperchar],0	;reset value
 		call	isdosdbcs
 	jz	@@notdosv
 		cmp al,3
@@ -2941,16 +2941,16 @@ if DBCSDOSV
 		call	testb800
 	jnc	@@notdosv
 @@vm3sor70:
-		mov	[cs:dbcsbytesperchar], 2	; simulated vm3
+		mov	[dbcsbytesperchar], 2	; simulated vm3
 	jmp	@@vm3send
 @@vm71or73:
-		mov	[cs:dbcsbytesperchar], 4	; vm73
+		mov	[dbcsbytesperchar], 4	; vm73
 @@vm3send:
   if	VTEXT	;the driver has 255-column buffer for DOS/V video modes
   else		;the driver has 80-column buffer for DOS/V video modes
 	call	is80column; CF (0=Yes, 1=No)
 	jnc	@@vmis80column
-	mov	[cs:dbcsbytesperchar], 0	;if >80 columns, disable DBCS support to avoid buffer overflow
+	mov	[dbcsbytesperchar], 0	;if >80 columns, disable DBCS support to avoid buffer overflow
   endif
 @@vmis80column:
 @@notdosv:
@@ -3076,12 +3076,6 @@ endif
 		shr	ax,cl
 
 @@setcommon:
-if DBCSDOSV
-		cmp	[dbcsbytesperchar],0
-		je	@@notdbcsvm03
-;		mov	di,200
-@@notdbcsvm03:
-endif
 		mov	[screenheight],di
 		mov	[scanline],ax		; screen line width in bytes
 		mov	[bitmapshift],cl	; log2(screen/memory ratio)

--- a/ctmouse.asm
+++ b/ctmouse.asm
@@ -442,14 +442,12 @@ endif						; -X- USERIL
 ;----- for DOS/V support -----
 if DBCSDOSV
 	oldint10calling	db	0
-
-	db 'DBCSBuf_Begin->'
 if VTEXT
 	dbcsstrbuf	db	4*256 dup (?)	;max 255 chr in line
 else
 	dbcsstrbuf	db	4*81 dup (?)	;max 80 chr in line
 endif
-	db '<-End_DBCSBuf'
+
 ifdef DBCSDOSVDEBUG
 	dbcsdebugtext	db	2*80 dup (?)
 DEBUGOUT	macro	val	;logging to 86Box POST card

--- a/ctmouse.asm
+++ b/ctmouse.asm
@@ -499,21 +499,6 @@ DEBUGSCRWRITE	macro
 	pop		ax
 	pop		es
 endm
-DEBUGFPRINT macro val8
-	push ax
-	push cx
-	push dx
-	mov	al,val8
-	call bintohex	;dh,dl=hex in char code
-	mov ah,03ch
-	xor cx,cx
-	mov dx,Name_FileDbg
-	int 021h
-
-	pop	dx
-	pop	cx
-	pop	ax
-endm
 DEBUGPRINT macro val8,dcposx
 	push ax
 	push dx

--- a/ctmouse.asm
+++ b/ctmouse.asm
@@ -40,7 +40,7 @@ FOOLPROOF	 = 1		; check driver arguments validness
 USE28		 = 0		; include code for INT 33/0028 function
 USERIL           = 0		; include code for INT 10/Fn EGA functions
 DBCSDOSV	 = 1        ; include code for DOS/V
-DBCSMSG	     = 1        ; enable bilingual message for DOS/V
+DBCSMSG		 = 1        ; enable bilingual message for DOS/V
 VTEXT		 = (1 AND DBCSDOSV)	; support over 80x25 text mode for DOS/V
 
 ; %define PS2DEBUG 1		; print debug messages for PS2serv calls
@@ -2683,50 +2683,6 @@ is80column	proc
 is80column	endp
 
 ;========================================================================
-;    Search a V-Text driver and get the vector address for mouse funcs
-;========================================================================
-; In:   none
-; Out:	CF (0=installed, 1=not installed or error)
-; Use:	
-; Modf:	none
-; Call: none
-;if VTEXT
-;getvtext	proc
-;	push	es
-;	push	ax
-;	push	bx
-;	push	cx
-;	mov	ax,01131h
-;	xor	cx,cx
-;	int	10h
-;	or	cx,cx
-;	jz	@@novtext	;CX=0 if the v-text driver is not installed
-;	mov	ax,05010h
-;	int	15h
-;	jc	@@novtext
-;	mov	bx,[bx+0Ah]	;get FAR pointer for the function parameter table of V-text driver
-;	mov	es,[bx+08h]
-;	SAVEFAR	[cs:vt_ptrFuncTable],es,bx
-;	mov	ax,es:[bx+0EH]	;get NEAR pointer for cursor functions
-;	mov	[cs:vt_ptrSetCursorShape],ax
-;	mov	ax,es:[bx+10H]
-;	mov	[cs:vt_ptrPutCursor],ax
-;	mov	ax,es:[bx+12H]
-;	mov	[cs:vt_ptrEraseCursor],ax
-;	clc
-;	jmp	@@endvtext
-;@@novtext:
-;	mov	word ptr [cs:vt_ptrFuncTable],0;reset pointer
-;	stc
-;@@endvtext:
-;	pop	cx
-;	pop	bx
-;	pop	ax
-;	pop	es
-;	ret
-;getvtext	endp
-;endif
-;========================================================================
 ;    Determine the video memory is simulated
 ;========================================================================
 ; In:   none
@@ -2935,7 +2891,7 @@ if DBCSDOSV
 		cmp	al,071h
 	je	@@vm71or73
   endif
-	jne	@@notdosv
+	jmp	@@notdosv
 @@vm3:
 ; if $disp.sys is active, the actual video memory is located at A0000-AFFFFh
 		call	testb800

--- a/ctmouse.asm
+++ b/ctmouse.asm
@@ -2658,6 +2658,31 @@ isdosdbcs	proc
 isdosdbcs	endp
 
 ;========================================================================
+;    Does the current video mode have eq or less than 80 columns?
+;========================================================================
+; In:   none
+; Out:	CF (0=Yes, 1=No)
+; Use:	
+; Modf:	none
+; Call: none
+is80column	proc
+	push	ax
+	push	bx
+	mov	ah,0Fh
+	int	10h
+	cmp	ah,80
+	ja	@@above80
+	clc
+	jmp	@@exit
+@@above80:
+	stc
+@@exit:
+	pop	bx
+	pop	ax
+	ret
+is80column	endp
+
+;========================================================================
 ;    Search a V-Text driver and get the vector address for mouse funcs
 ;========================================================================
 ; In:   none
@@ -2921,6 +2946,13 @@ if DBCSDOSV
 @@vm71or73:
 		mov	[cs:dbcsbytesperchar], 4	; vm73
 @@vm3send:
+  if	VTEXT	;the driver has 255-column buffer for DOS/V video modes
+  else		;the driver has 80-column buffer for DOS/V video modes
+	call	is80column; CF (0=Yes, 1=No)
+	jnc	@@vmis80column
+	mov	[cs:dbcsbytesperchar], 0	;if >80 columns, disable DBCS support to avoid buffer overflow
+  endif
+@@vmis80column:
 @@notdosv:
 endif
 


### PR DESCRIPTION
* Fixed a bug that running in video modes that have more than 80 columns may cause a buffer overflow.
* Added support for video modes 70h, 71h (variable-size CGA text modes), used by SVGA V-Text drivers.